### PR TITLE
Add generation of chunked html with pandoc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/edge-iot-arch-guide-chunkedhtml/
 /edge-iot-arch-guide.html
 /edge-iot-arch-guide.pdf
 /edge-iot-arch-guide.txt

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ NAME = edge-iot-arch-guide
 TXT = $(NAME).txt
 PDF = $(NAME).pdf
 HTML = $(NAME).html
+CHUNKEDHTML = $(NAME)-chunkedhtml
 
 # List sources files here; order is meaningful.
 MARKDOWNS = \
@@ -19,7 +20,7 @@ MARKDOWNS = \
 
 PANDOC_OPTS = -f markdown+rebase_relative_paths
 
-all: $(TXT) $(MAN) $(PDF) $(HTML)
+all: $(TXT) $(MAN) $(PDF) $(HTML) $(CHUNKEDHTML)
 
 $(TXT):	$(MARDOWNS)
 	pandoc -o $@ $(MARKDOWNS) $(PANDOC_OPTS) -t plain
@@ -27,5 +28,10 @@ $(TXT):	$(MARDOWNS)
 $(PDF) $(HTML):	$(MARDOWNS)
 	pandoc -o $@ $(MARKDOWNS) $(PANDOC_OPTS)
 
+$(CHUNKEDHTML):	$(MARDOWNS)
+	rm -fr $@
+	pandoc -o $@ $(MARKDOWNS) $(PANDOC_OPTS) \
+		--metadata title="Edge IoT Arch Guide" -t chunkedhtml
+
 clean:
-	rm -fr $(TXT) $(PDF) $(HTML)
+	rm -fr $(TXT) $(PDF) $(HTML) $(CHUNKEDHTML)


### PR DESCRIPTION
Update the Makefile to generate "chunked" HTML with pandoc, with multiple files under a directory.

Also, update the gitignore.

This is a follow-up to #26, made possible by #23.

For the moment the generated top-level index is mostly empty and only points at chapter 1, which is the real top-level. This is not ideal and can certainly be improved in the future.