### PR TITLE
Generate documents on github CI

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,38 @@
+---
+name: 'Edge IoT Arch Guide CI Build'
+
+# yamllint disable-line rule:truthy
+on:
+  push:
+    branches: '**'
+    tags: 'v*'
+
+  pull_request:
+    branches: main
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+      - name: 'Identify Version'
+        run: |
+          echo "EIAG_VERSION=$(git describe --always)" >> $GITHUB_ENV
+
+      - name: 'Install Ubuntu required packages'
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install pandoc texlive
+
+      - name: 'Generate documents'
+        run: |
+          make
+
+      - name: 'Upload artifacts'
+        uses: actions/upload-artifact@v4
+        with:
+          name: edge-iot-arch-guide-${{ env.EIAG_VERSION }}
+          path: |
+            edge-iot-arch-guide*


### PR DESCRIPTION
Add a github workflow YAML file to run jobs on github CI. For each push or pull request, we generate documents in various formats with pandoc and upload them.

This is a minimal start at a CI, shamelessly inspired from [EBBR CI](https://github.com/ARM-software/ebbr/blob/main/.github/workflows/main.yaml).

This works already with the three generated formats but should cope nicely with #30, and generate and upload the chunked HTML directory when it is merged.
