### PR TITLE
fw update: convert table caption

### DIFF
--- a/source/FWU/MBFW/chapter3-fwupdate.md
+++ b/source/FWU/MBFW/chapter3-fwupdate.md
@@ -33,7 +33,7 @@ construct the ESRT table.
 Each image entry in the FWU image directory exposes a set of fields which map directly to the
 EFI_FIRMWARE_IMAGE_DESCRIPTOR as defined in the following table:
 
-.. table:: EFI_FIRMWARE_IMAGE_DESCRIPTOR Implementation Requirements
+Table: EFI_FIRMWARE_IMAGE_DESCRIPTOR Implementation Requirements
 
    | FWU image directory entry field | EFI_FIRMWARE_IMAGE_DESCRIPTOR |
    |---------------------------------|-------------------------------|


### PR DESCRIPTION
The EFI_FIRMWARE_IMAGE_DESCRIPTOR Implementation Requirements table caption uses the `.. table::' reStructuredText syntax and does not render correctly.

Convert it to markdown with table_captions extension[1], which displays well enough on github and renders nicely with pandoc.

Link: https://pandoc.org/MANUAL.html#extension-table_captions [1]
Fixes: #38